### PR TITLE
remove redundant dev notion title

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# DEV-
-
 ## Changes summary
 
 


### PR DESCRIPTION
## Changes summary

Removes the redundant notion dev ticket requirement in the description as this does not automatically create a the link to notion.
Instead, devs should put the ticket number in the branch name and in the PR title as [DEV-xxx]
